### PR TITLE
Adjust registered services according to aspnet/Hosting#509

### DIFF
--- a/src/AspNet.Hosting.Extensions/HostingExtensions.cs
+++ b/src/AspNet.Hosting.Extensions/HostingExtensions.cs
@@ -83,6 +83,7 @@ namespace Microsoft.AspNet.Builder {
 
             return app.Isolate(builder => builder.Map(path, configuration), serviceConfiguration);
         }
+
         /// <summary>
         /// Creates a new isolated application builder which gets its own <see cref="ServiceCollection"/>, which only
         /// has the default services registered. It will not share the <see cref="ServiceCollection"/> from the
@@ -112,7 +113,6 @@ namespace Microsoft.AspNet.Builder {
             [NotNull] Action<IApplicationBuilder> configuration) {
             return app.Isolate(configuration, services => services.BuildServiceProvider());
         }
-
 
         /// <summary>
         /// Creates a new isolated application builder which gets its own <see cref="ServiceCollection"/>, which only
@@ -216,18 +216,6 @@ namespace Microsoft.AspNet.Builder {
 
                 if (defaultPlatformServices.Runtime != null) {
                     services.TryAdd(ServiceDescriptor.Instance(defaultPlatformServices.Runtime));
-                }
-
-                if (defaultPlatformServices.AssemblyLoadContextAccessor != null) {
-                    services.TryAdd(ServiceDescriptor.Instance(defaultPlatformServices.AssemblyLoadContextAccessor));
-                }
-
-                if (defaultPlatformServices.AssemblyLoaderContainer != null) {
-                    services.TryAdd(ServiceDescriptor.Instance(defaultPlatformServices.AssemblyLoaderContainer));
-                }
-
-                if (defaultPlatformServices.LibraryManager != null) {
-                    services.TryAdd(ServiceDescriptor.Instance(defaultPlatformServices.LibraryManager));
                 }
             }
 


### PR DESCRIPTION
David Fowler removed some registered services from the `WebHostBuilder`. The adjusted method is supposed to register the same services as the `WebHostBuilder` (like mentioned in the method documentation).
